### PR TITLE
feat: 챌린지 초대 가능 리스트 / 최근 같이 챌린지한 유저 리스트 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,11 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    //JsonSimple
+    implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+
+    //hypersistence-utils-hibernate-63
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-60:3.3.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hana/api/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hana/api/challenge/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package com.hana.api.challenge.controller;
 
 
 import com.hana.api.challenge.dto.request.ChallengeCreateRequest;
+import com.hana.api.challenge.dto.request.InvitationListRequest;
 import com.hana.api.challenge.service.ChallengeService;
 import com.hana.api.user.entity.User;
 import com.hana.common.type.CurrentUser;
@@ -29,6 +30,19 @@ public class ChallengeController {
     public ResponseEntity<?> create(@RequestBody ChallengeCreateRequest challengeCreateRequest) {
         return challengeService.create(challengeCreateRequest);
     }
+
+    @Operation(summary = "초대 가능 유저 조회", description = "챌린지 생성 시 초대 가능한 유저를 조회하는 API 입니다.")
+    @PostMapping("/invitation-list")
+    public ResponseEntity<?> getInvitationList(@CurrentUser User user, @RequestBody InvitationListRequest invitationListRequest){
+        return challengeService.getInvitationList(user,invitationListRequest);
+    }
+
+    @Operation(summary = "최근 챌린지 같이 진행한 유저 조회", description = "최근 챌린지 같이 진행한 유저를 조회하는 API 입니다.")
+    @RequestMapping("/recent-list")
+    public ResponseEntity<?> getRecentList(@CurrentUser User user){
+        return challengeService.getRecentList(user);
+    }
+
     @Operation(summary = "진행중인 챌린지 조회", description = "진행중인 챌린지를 조회하는 API 입니다.")
     @RequestMapping("/ongoing")
     public ResponseEntity<?> getOngoingChallenges(@CurrentUser User user) {

--- a/src/main/java/com/hana/api/challenge/dto/request/InvitationInfo.java
+++ b/src/main/java/com/hana/api/challenge/dto/request/InvitationInfo.java
@@ -1,0 +1,13 @@
+package com.hana.api.challenge.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class InvitationInfo{
+    private String name;
+    private String phoneNum;
+}

--- a/src/main/java/com/hana/api/challenge/dto/request/InvitationListRequest.java
+++ b/src/main/java/com/hana/api/challenge/dto/request/InvitationListRequest.java
@@ -1,0 +1,16 @@
+package com.hana.api.challenge.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.List;
+
+
+
+@ToString
+@Getter
+@Setter
+public class InvitationListRequest {
+    List<InvitationInfo> invitationList;
+}

--- a/src/main/java/com/hana/api/challenge/dto/response/InvitationListResponse.java
+++ b/src/main/java/com/hana/api/challenge/dto/response/InvitationListResponse.java
@@ -1,0 +1,14 @@
+package com.hana.api.challenge.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class InvitationListResponse {
+    private String name;
+    private String phoneNum;
+    private String realName;
+}

--- a/src/main/java/com/hana/api/challenge/entity/Challenge.java
+++ b/src/main/java/com/hana/api/challenge/entity/Challenge.java
@@ -40,6 +40,5 @@ public class Challenge extends BaseEntity {
     private Integer challengeTargetAmount;
 
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JsonBackReference
     private List<ChallengeUsers> challengeUsers;
 }

--- a/src/main/java/com/hana/api/challenge/entity/ChallengeUsers.java
+++ b/src/main/java/com/hana/api/challenge/entity/ChallengeUsers.java
@@ -34,11 +34,13 @@ public class ChallengeUsers {
     @ManyToOne(cascade = CascadeType.ALL)
     @MapsId("challengeCode")
     @JoinColumn(name = "challenge_code", referencedColumnName = "challenge_code")
+    @JsonBackReference
     private Challenge challenge;
 
     @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "state", referencedColumnName = "state")
     @JoinColumn(name = "created_date", referencedColumnName = "created_date")
+    @JsonBackReference
     private Challenge challengeBase;
     
     private Boolean challengeUserResult;

--- a/src/main/java/com/hana/api/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/hana/api/challenge/repository/ChallengeRepository.java
@@ -2,6 +2,8 @@ package com.hana.api.challenge.repository;
 
 import com.hana.api.challenge.dto.query.HotChallengeInterface;
 import com.hana.api.challenge.entity.Challenge;
+import com.hana.api.user.entity.User;
+import com.hana.common.type.State;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -12,6 +14,10 @@ import java.util.Optional;
 @Repository
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     Optional<Challenge> findByChallengeCode(String challengeCode);
+
+    List<Challenge> findAllChallengeByChallengeUsers_UserAndState(User user, State state);
+
+    List<Challenge> findTop3ByChallengeUsers_UserOrderByCreatedDateDesc(User user);
 
     @Query(value = "SELECT COUNT(*) as challengeCount, CHALLENGE_CATEGORY FROM challenge GROUP BY CHALLENGE_CATEGORY ORDER BY COUNT(*) DESC LIMIT 3", nativeQuery = true)
     List<HotChallengeInterface> findTop3ByChallengeCategory();

--- a/src/main/java/com/hana/api/user/entity/User.java
+++ b/src/main/java/com/hana/api/user/entity/User.java
@@ -58,7 +58,7 @@ public class User extends BaseEntity {
     private String userAddress;
 
     @Column(name = "user_profile", length = 300)
-    @ColumnDefault("https://sync-bucket1.s3.ap-northeast-2.amazonaws.com/profile/default.png")
+    @ColumnDefault("'https://sync-bucket1.s3.ap-northeast-2.amazonaws.com/profile/default.png'")
     private String userProfile;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/hana/api/user/repository/UserRepository.java
+++ b/src/main/java/com/hana/api/user/repository/UserRepository.java
@@ -9,6 +9,8 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByUserId(String userId);
+
+    Optional<User>findByUserPhone(String userPhone);
     boolean existsByUserId(String userId);
 }
 

--- a/src/main/java/com/hana/api/user/service/UserService.java
+++ b/src/main/java/com/hana/api/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.hana.api.user.service;
 
+import com.hana.api.account.entity.Account;
 import com.hana.api.account.service.AccountService;
 import com.hana.api.challenge.repository.ChallengeUsersRepository;
 import com.hana.api.user.dto.request.LoginRequest;
@@ -52,7 +53,8 @@ public class UserService {
         if(userRepository.existsByUserId(signupRequest.getUserId())){
             throw new NameDuplicateException(ErrorCode.USER_NAME_DUPLICATION);
         }
-
+        Account account = accountService.createAccount(signupRequest.getAccountName(), signupRequest.getAccountBalance());
+        log.info("\n\n\n"+account.toString()+"\n\n\n");
         User user =
                 User.builder()
                         .userCode(UuidGenerator.generateUuid())
@@ -65,9 +67,9 @@ public class UserService {
                         .userPhone(signupRequest.getUserPhone())
                         .userAddress(signupRequest.getUserAddress())
                         .userRole(Role.getRole(signupRequest.getUserRole()))
-                        .account(accountService.createAccount(signupRequest.getAccountName(), signupRequest.getAccountBalance()))
+                        .account(account)
                         .build();
-
+        log.info("\n\n\n"+user.toString()+"\n\n\n");
         userRepository.save(user);
 
         return response.success("회원가입 완료");


### PR DESCRIPTION
# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
<br>

🧭 작업 브랜치
---

<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
본인이 초대 가능한 유저 리스트 API 구현
최근 같이 챌린지에 참여한 유저 리스트 API 구현
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---
[본인의 전화번호부에 등재되어 있는 유저만 검색되게끔 하여 전화번호 목록과 DB 내부 번호 목록을 대조, 공통 부분을 찾고 이를 반환하는 API 구현](https://www.notion.so/users-invitation-list-ef3e470a8f1e4eb6800dcc57dfbccce0?pvs=4)

[최근 챌린지를 같이 진행한 유저들 목록에서 본인 및 중복을 제외하고 다른 유저들 목록을 반환하는 API 구현](https://www.notion.so/users-recent-list-0fd977531e9849948f9c6d2cf3e38e86?pvs=4)
<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
