### PR TITLE
fix: Account_AccountAnalyses fetch Type EAGER로 변경

### DIFF
--- a/src/main/java/com/hana/api/account/entity/Account.java
+++ b/src/main/java/com/hana/api/account/entity/Account.java
@@ -1,5 +1,7 @@
 package com.hana.api.account.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.hana.api.user.entity.User;
 import com.hana.common.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -8,6 +10,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -31,14 +34,15 @@ public class Account extends BaseEntity {
 //    private List<AccountHistory> accountHistories;
 
     @OneToOne(mappedBy = "account", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonBackReference
     private User user;
 
     @OneToOne
     @JoinColumn(name = "card_num")
     private Card card;
 
-    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<AccountAnalysis> accountAnalyses;
+    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private List<AccountAnalysis> accountAnalyses = new ArrayList<>();
 
     public Long updateAccountBalance(Long amount){
         this.accountBalance -= amount;

--- a/src/main/java/com/hana/api/account/entity/AccountAnalysis.java
+++ b/src/main/java/com/hana/api/account/entity/AccountAnalysis.java
@@ -1,5 +1,6 @@
 package com.hana.api.account.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.hana.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ public class AccountAnalysis extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "account_num", nullable = false)
+    @JsonBackReference
     private Account account;
 
     private Integer analysisTotal;

--- a/src/main/java/com/hana/api/account/entity/Card.java
+++ b/src/main/java/com/hana/api/account/entity/Card.java
@@ -1,5 +1,7 @@
 package com.hana.api.account.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.hana.api.account.dto.response.CardResponseDto;
 import com.hana.common.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -28,7 +30,8 @@ public class Card extends BaseEntity {
     @Column(length = 3)
     private String cardCvc;
 
-    @OneToOne(mappedBy = "card", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "card", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @JsonBackReference
     private Account account;
 
     public CardResponseDto getCardResponseDto(){


### PR DESCRIPTION
# 🪩 PR 요약 <!-- feat: 유저 마이 프로필 수정 api 추가 -->
fix: Account_AccountAnalyses fetch Type EAGER로 변경
<br>

🧭 작업 브랜치
---

<!-- ex) feature/profile -->
<br>

📚 작업 내용
---
Account와 AccountAnalyses 간의 계층 관계 수정
<!-- ex) 마이 프로필 수정하는 api를 추가했습니다. -->
<br>

📝 상세 설명
---
Account-AccountAnalyses 정의 및 Fetch type에 의한
_Could not write JSON: failed to lazily initialize a collection of role_
에러 핸들링으로 Fetch Type 변경
<!-- 작업 내용 상세 설명, 질문 사항, 주의할 점 등 -->
<br>
